### PR TITLE
Avoid undefined

### DIFF
--- a/_posts/2019-09-25-opaque-constraint-synonyms.md
+++ b/_posts/2019-09-25-opaque-constraint-synonyms.md
@@ -77,10 +77,10 @@ Next, we satisfy the superclass constraints
 
 {% highlight haskell %}
 instance Read Opaque where
-  readsPrec = undefined
+  readsPrec _ _ = []
 
 instance Show Opaque where
-  showsPrec = undefined
+  showsPrec _ = \case {}
 {% endhighlight %}
 
 Note that these two instances only exist so that the constraint is


### PR DESCRIPTION
Some codebases prohibit the use of `undefined`, partial functions, and other constructs that can produce a bottom value. Replace our instance methods with ones that behave like those on the `Void` type instead, so that this example will be more directly translatable to them.

(Alternatively, instead of doing this, you could enable the `EmptyDataDeriving` GHC extension and then just use `deriving (Read,Show)`.)